### PR TITLE
Fix: 質問画面で、着手禁止点や盤外の点も選択できてしまう問題を修正

### DIFF
--- a/client/src/components/GoBoard.tsx
+++ b/client/src/components/GoBoard.tsx
@@ -186,6 +186,9 @@ export default function GoBoard({
             }
 
             newBoard.addEventListener('click', (x: number, y: number) => {
+	      // 着手禁止点、盤外の点などは無視
+	      if(!game.isValid(x, y)) return
+
               // 公式座標システム（相対座標）
               const coordinate = wgoToSgfCoords(x, y)
               onCoordinateSelect(coordinate)


### PR DESCRIPTION
### 概要
質問画面での碁盤クリック時、ルール上石を置けない場所（すでに石がある場所、着手禁止点、盤外の点など）に石が置けてしまう不具合を修正しました。

### 変更内容
* `game.isValid(x, y)` で座標の正当性をチェックし、無効な場合は以下で早期リターン

`client/src/components/GoBoard.tsx` 188行目付近
```diff
newBoard.addEventListener('click', (x: number, y: number) => {
+ // 着手禁止点、盤外の点などは無視
+ if(!game.isValid(x, y)) return
+
  // 公式座標システム（相対座標）
  const coordinate = wgoToSgfCoords(x, y)
  onCoordinateSelect(coordinate)