### PR TITLE
トップページにおいて各問題ごとの回答状況を表示するように修正

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -189,6 +189,17 @@ button:hover {
   color: #333;
 }
 
+.problem-hasUserAnswered {
+  font-weight: 500;
+}
+
+.already-answered {
+  color: #4caf50;
+}
+.notyet-answered {
+  color: #f44336;
+}
+
 .problem-date {
   font-size: 12px;
   color: #999;


### PR DESCRIPTION
◯ 修正箇所
① client/src/App.css
② client/src/pages/Home.tsx

◯ 修正理由
今後問題数が増えていくことを考えた時に、回答し忘れている問題があるかどうかをトップページで確認できるようにしておけると便利だと思い、回答状況の表示を追加するための修正しました。