### PR TITLE
description.txt で turn を必須から任意に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ moves: 30
 description: 次の一手を考えてください。着手とその理由を回答してください。
 ```
 
-- **turn**: 手番（black または white）（必須）
+- **turn**: 手番（black または white）（任意）
 - **moves**: 表示する手数（任意、省略時は最終手まで）
 - **description**: 問題の説明文（必須）
 

--- a/client/src/components/GoBoard.tsx
+++ b/client/src/components/GoBoard.tsx
@@ -9,6 +9,7 @@ interface GoBoardProps {
   showClickable?: boolean
   resultsData?: Record<string, { votes: number; answers: any[] }>
   maxMoves?: number // movesパラメータ対応
+  derivedTurn: "black" | "white"
 }
 
 declare global {
@@ -23,6 +24,7 @@ export default function GoBoard({
   showClickable = false,
   resultsData,
   maxMoves,
+  derivedTurn,
 }: GoBoardProps) {
   const boardRef = useRef<HTMLDivElement>(null)
   const [board, setBoard] = useState<any>(null)
@@ -138,8 +140,8 @@ export default function GoBoard({
             let lastClickMarker: any = null
 
             // 現在の手番を取得（黒番: 1, 白番: -1）
-            const currentTurn = game.turn
-
+            const currentTurn = derivedTurn === "black" ? window.WGo.B : window.WGo.W
+	    
             // カスタム着手点マーカーハンドラーを定義
             const clickMarkerHandler = {
               stone: {
@@ -187,7 +189,7 @@ export default function GoBoard({
 
             newBoard.addEventListener('click', (x: number, y: number) => {
               // 着手禁止点、盤外の点などは無視
-              if (!game.isValid(x, y)) return
+              if (!game.isValid(x, y, currentTurn)) return
 
               // 公式座標システム（相対座標）
               const coordinate = wgoToSgfCoords(x, y)

--- a/client/src/pages/Questionnaire.tsx
+++ b/client/src/pages/Questionnaire.tsx
@@ -120,6 +120,7 @@ export function Questionnaire() {
               maxMoves={problem.moves}
               onCoordinateSelect={setSelectedCoordinate}
               showClickable={true}
+              derivedTurn={problem.turn}
             />
           </div>
 


### PR DESCRIPTION
#19 を解決
`description.txt` で turn の項目を任意に変更しました。

### ロジック
`description.txt` で turn の項目が設定されているときはその手番を優先し、出題局面の実際の手番と異なっていたとしても採用する。
turn が設定されていなければ、moves の偶奇によって turn を判定する。 moves が奇数なら turn: white, 偶数なら turn: black を設定する。
turn も move も設定されていなければ、sgfファイルから turn を判定する。 sgf ファイル中の最終手が B(黒番)なら、turn: white, W(白番) なら、 turn: black を設定する。

### 補遺
サーバー側とクライアント側で sgf のパースロジックが異なっているので、別で Issue を立てます