### PR TITLE
SGFファイルに分岐構造がある場合に対応

### DIFF
--- a/client/src/components/GoBoard.tsx
+++ b/client/src/components/GoBoard.tsx
@@ -463,7 +463,7 @@ export default function GoBoard({
 
     // SGFから手順を順番通りに抽出（黒番Bと白番Wを交互に）
     // メインのゲーム木を取得し、手順の再現はメインのルートに絞る
-    const sgfMainBranch = sgfContent.split(')')[0]
+    const sgfMainBranch = extractMainRoute(sgfContent)
     const movePattern = /;([BW])\[([a-s][a-s])\]/g
     let match
 
@@ -479,6 +479,40 @@ export default function GoBoard({
     }
 
     return moves
+  }
+
+  // SGFからメインルートを取得
+  // コメント内の `)` は無視し、分岐を生成する `)` 以前を取得する
+  const extractMainRoute = (sgfContent: string): string => {
+    let inValue = false   // '[' ～ ']' 内に居るか
+    let escape  = false   // 直前が '\' かどうか
+    let result  = ''
+
+    for (const ch of sgfContent) {
+      if (inValue) { // [ ] プロパティの内部
+	result += ch
+	if (escape) {
+          escape = false
+	}
+	else if (ch === '\\') escape = true   // 次の 1 文字をエスケープ
+	else if (ch === ']')  inValue = false // プロパティ終了
+	continue
+      }
+
+      // プロパティ値の外
+      if (ch === '[') {
+	inValue = true
+	result += ch
+	continue
+      }
+
+      if (ch === ')') {
+	// これ以降は分岐なので捨てる
+	break
+      }
+      result += ch
+    }
+    return result
   }
 
   // 座標変換（公式座標システム準拠）

--- a/client/src/components/GoBoard.tsx
+++ b/client/src/components/GoBoard.tsx
@@ -462,10 +462,12 @@ export default function GoBoard({
     const moves: Array<{ color: number; x: number; y: number }> = []
 
     // SGFから手順を順番通りに抽出（黒番Bと白番Wを交互に）
+    // メインのゲーム木を取得し、手順の再現はメインのルートに絞る
+    const sgfMainBranch = sgfContent.split(')')[0]
     const movePattern = /;([BW])\[([a-s][a-s])\]/g
     let match
 
-    while ((match = movePattern.exec(sgfContent)) !== null) {
+    while ((match = movePattern.exec(sgfMainBranch)) !== null) {
       const color = match[1] === 'B' ? window.WGo.B : window.WGo.W
       const coords = match[2]
 


### PR DESCRIPTION
#20 の補遺を修正

### 概要
SGFファイルに分岐構造がある場合に、問題の表示がうまくいかない問題を修正しました。
検討内容を保存した後のsgfファイルでも、本譜をメインのルートにしておけばこれまで通り使えます。

### 修正内容
`client/src/components/GoBorad.tsx` の `ParseSgfMoves` について、パースのロジックを変更しました。
- 現状: SGFファイル内の `/;([BW])\[([a-s][a-s])\]/g` にマッチした部分を WGo.js 用に変換して moves として記録する
- 修正: SGFファイルのうち、最初にあらわれる `)` までを主分岐とし、主分岐内の手順にのみ上記の正規表現マッチを適用する。

サーバー側のパースは #20 で追加したロジックで対応しています。

### 未対応のSGF形式について
SGF は `;` の直後に `W[dd]` 形式のmoveが来るとは限らないことに注意してください。
例えば `(;AB[pd][dp][pp][dd][pj][dj][jp][jd][jj];W[fc])` は通常の9子局だが、いごもんではクライアント、サーバーともに未対応となっています。

~~着手コメントに `()` が入ってる SGF にも対応できてないです。~~
~~例えば `(;B[dc]C[初手(これはモクハズシと呼ばれている)];)` はゲーム木の取得に失敗し、意図しない挙動となります。~~
これは続く commit で修正しました。

特殊なsgfに対応しようとするとキリがないので以上の二つは未対応のままとしました。
手製のparseを辞めて、@sabaki/sgf のようなちゃんとした sgf parsing ライブラリを使うという方向性も将来的にはありうるのかもしれません。