### PR TITLE
Fix #29: OGP用の画像生成で抜かれた石が残っている問題を解決した

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^6.10.1",
+        "@sabaki/go-board": "^1.4.3",
         "@sabaki/sgf": "^3.4.7",
         "canvas": "^3.1.2",
         "chokidar": "^4.0.3",
@@ -1408,6 +1409,11 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sabaki/go-board": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@sabaki/go-board/-/go-board-1.4.3.tgz",
+      "integrity": "sha512-tXonP7vw7bYcXKSVrN1bhkb/QQi5EfTbDSflBffSp2iabbFbz4JyhEyw0ekbuwR0ntBq6iHky6BfCGF69Z4ttg=="
     },
     "node_modules/@sabaki/sgf": {
       "version": "3.4.7",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@prisma/client": "^6.10.1",
     "@sabaki/sgf": "^3.4.7",
+    "@sabaki/go-board": "^1.4.3",
     "canvas": "^3.1.2",
     "chokidar": "^4.0.3",
     "cors": "^2.8.5",

--- a/server/utils/ogp-generator.ts
+++ b/server/utils/ogp-generator.ts
@@ -2,6 +2,7 @@
 import { createCanvas } from 'canvas'
 import fs from 'fs'
 import path from 'path'
+import { buildBoardFromSGF } from '../../lib/sgf-utils'
 
 interface StonePosition {
   x: number
@@ -147,45 +148,9 @@ export class OGPGenerator {
 
   private parseSGF(sgfContent: string, maxMoves?: number): StonePosition[] {
     const stones: StonePosition[] = []
-    const board: (0 | 1 | -1)[][] = Array(19)
-      .fill(null)
-      .map(() => Array(19).fill(0))
 
-    // 黒石の手を抽出
-    const blackMoves = [...sgfContent.matchAll(/;B\[([a-s])([a-s])\]/g)]
-    // 白石の手を抽出
-    const whiteMoves = [...sgfContent.matchAll(/;W\[([a-s])([a-s])\]/g)]
-
-    // すべての手を順番に処理（簡易版）
-    let moveCount = 0
-    const allMoves: { match: RegExpMatchArray; color: 'black' | 'white' }[] = []
-
-    // SGFの順序を保持するため、インデックスも記録
-    blackMoves.forEach((match) => {
-      allMoves.push({ match, color: 'black' })
-    })
-    whiteMoves.forEach((match) => {
-      allMoves.push({ match, color: 'white' })
-    })
-
-    // SGF内での出現順にソート（簡易版）
-    allMoves.sort((a, b) => {
-      const aIndex = sgfContent.indexOf(a.match[0])
-      const bIndex = sgfContent.indexOf(b.match[0])
-      return aIndex - bIndex
-    })
-
-    // 指定された手数まで処理
-    for (const move of allMoves) {
-      if (maxMoves !== undefined && moveCount >= maxMoves) break
-
-      const x = move.match[1].charCodeAt(0) - 'a'.charCodeAt(0)
-      const y = move.match[2].charCodeAt(0) - 'a'.charCodeAt(0)
-
-      // 石を配置（取られた石の処理は簡易的に省略）
-      board[x][y] = move.color === 'black' ? 1 : -1
-      moveCount++
-    }
+    // SGFをパースして盤面を生成
+    const board = buildBoardFromSGF(sgfContent, maxMoves)
 
     // 盤面の状態から石の位置を抽出
     for (let x = 0; x < 19; x++) {


### PR DESCRIPTION
#29 を解決

### 変更内容
`@sabaki/go-board` を導入し、`lib/sgf-utils.ts` に囲碁のルールに沿った盤面生成の処理を追加し、`/server/utils/ogp-generator.ts` での画像生成処理を書き換えました。